### PR TITLE
chore: setup mysql via docker compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+MYSQL_ROOT_PASSWORD=my_secure_password
+MYSQL_DATABASE=cafe-crafter-main-db
+MYSQL_USER=my_user
+MYSQL_PASSWORD=my_user_password

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,17 @@
+# How to run DB locally?
+
+> Run the following commands at the root of the project. (Outside of api or frontend)
+
+1. Create a .env file, you can copy the .env.example
+
+```shell
+    cp .env.example .env
+```
+
+2. Fill in all the fields with the values you want to use locally. Completely up to you.
+
+3. Spin up the container.
+
+```shell
+    docker compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: cafe-crafter-main-db
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${MYSQL_DATABASE}
+      MYSQL_USER: ${MYSQL_USER}
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql_data:/var/lib/mysql
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
# Context

Quickly setup a db to run locally

## Solution

- Added a docker compose to make the setup of the container easier
- Updated docs with steps of how to run the DB
- Added support for .env